### PR TITLE
add json output (whole data for requested layout)

### DIFF
--- a/i3keys.go
+++ b/i3keys.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/RasmusLindroth/i3keys/json"
 	"github.com/RasmusLindroth/i3keys/svg"
 	"github.com/RasmusLindroth/i3keys/text"
 	"github.com/RasmusLindroth/i3keys/web"
@@ -17,8 +18,9 @@ func helpText(exitCode int) {
 	fmt.Print("\tAdd the flag -i for i3 and -s for Sway if you don't want autodetection\n\n")
 	fmt.Print("The commands are:\n\n")
 	fmt.Print("\tweb [port]\n\t\tstart the web ui and listen on random port or [port]\n\n")
-	fmt.Print("\ttext <layout> [mods]\n\t\toutput available keybindings in the terminal\n\n")
 	fmt.Print("\tsvg <layout> [dest] [mods]\n\t\toutputs one SVG file for each modifier group\n\n")
+	fmt.Print("\tjson <layout>\n\t\toutput all keybindings as json\n\n")
+	fmt.Print("\ttext <layout> [mods]\n\t\toutput available keybindings in the terminal\n\n")
 	fmt.Print("\tversion\n\t\tprint i3keys version\n\n")
 	fmt.Print("Arguments:\n\n")
 	fmt.Print("\t<layout>\n\t\tis required. Can be ISO or ANSI\n\n")
@@ -49,17 +51,17 @@ func main() {
 		port = os.Args[1+sIndex]
 	}
 
-	layoutCheck := len(os.Args) > 1+sIndex && (strings.ToUpper(os.Args[1+sIndex]) != "ISO" && strings.ToUpper(os.Args[1+sIndex]) != "ANSI")
-
-	if cmd == "text" && len(os.Args) < 2+sIndex || (cmd == "text" && layoutCheck) {
-		fmt.Println("You need to set the <layout> to ISO or ANSI")
-		os.Exit(2)
-	}
-
-	if (cmd == "svg" && len(os.Args) < 2+sIndex) ||
-		(cmd == "svg" && layoutCheck) {
-		fmt.Println("You need to set the <layout> to ISO or ANSI")
-		os.Exit(2)
+	layout := ""
+	if cmd == "text" || cmd == "json" || cmd == "svg" {
+		if len(os.Args) <= 1+sIndex {
+			fmt.Println("You need to set the <layout> to ISO or ANSI")
+			os.Exit(2)
+		}
+		layout = strings.ToUpper(os.Args[1+sIndex])
+		if layout != "ISO" && layout != "ANSI" {
+			fmt.Println("You need to set the <layout> to ISO or ANSI")
+			os.Exit(2)
+		}
 	}
 
 	switch cmd {
@@ -71,6 +73,8 @@ func main() {
 		} else {
 			text.Output(wm, os.Args[1+sIndex], os.Args[2+sIndex])
 		}
+	case "json":
+		json.Output(wm, layout)
 	case "svg":
 		if len(os.Args) < 3+sIndex {
 			svg.Output(wm, os.Args[1+sIndex], "", "")

--- a/json/output.go
+++ b/json/output.go
@@ -1,0 +1,59 @@
+package json
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/RasmusLindroth/i3keys/i3parse"
+	"github.com/RasmusLindroth/i3keys/keyboard"
+	"github.com/RasmusLindroth/i3keys/xlib"
+)
+
+type modeKeyboards struct {
+	Name      string
+	Keyboards []keyboard.Keyboard
+}
+
+// Output full json for the requested layout
+func Output(wm string, layout string) {
+	modes, keys, err := i3parse.ParseFromRunning(wm)
+
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	modifiers := xlib.GetModifiers()
+	groups := i3parse.GetModifierGroups(keys)
+
+	layoutModeDefault := modeKeyboards{Name: "(default)"}
+	for _, group := range groups {
+		kb, err := keyboard.MapKeyboard(layout, group, modifiers)
+		if err != nil {
+			log.Fatalln(err)
+		}
+		layoutModeDefault.Keyboards = append(layoutModeDefault.Keyboards, kb)
+
+	}
+
+	var layoutModes []modeKeyboards
+	layoutModes = append(layoutModes, layoutModeDefault)
+
+	for _, mode := range modes {
+		groups := i3parse.GetModifierGroups(mode.Bindings)
+
+		layoutMode := modeKeyboards{Name: mode.Name}
+
+		for _, group := range groups {
+			kb, err := keyboard.MapKeyboard(layout, group, modifiers)
+			if err != nil {
+				log.Fatalln(err)
+			}
+			layoutMode.Keyboards = append(layoutMode.Keyboards, kb)
+		}
+		layoutModes = append(layoutModes, layoutMode)
+	}
+
+	layoutJSON, _ := json.Marshal(layoutModes)
+	fmt.Printf("%s\n", layoutJSON)
+}

--- a/keyboard/layouts.go
+++ b/keyboard/layouts.go
@@ -8,7 +8,7 @@ import (
 	"github.com/RasmusLindroth/i3keys/xlib"
 )
 
-//ANSI holds evdev keys for an ANSI layout
+// ANSI holds evdev keys for an ANSI layout
 var ANSI = [][]string{
 	{"ESC", "FK01", "FK02", "FK03", "FK04", "FK05", "FK06", "FK07", "FK08", "FK09", "FK10", "FK11", "FK12", "PRSC", "SCLK", "PAUS"},
 	{"TLDE", "AE01", "AE02", "AE03", "AE04", "AE05", "AE06", "AE07", "AE08", "AE09", "AE10", "AE11", "AE12", "BKSP", "INS", "HOME", "PGUP", "NMLK", "KPDV", "KPMU", "KPSU"},
@@ -18,7 +18,7 @@ var ANSI = [][]string{
 	{"LCTL", "LWIN", "LALT", "SPCE", "RALT", "RWIN", "MENU", "RCTL", "LEFT", "DOWN", "RGHT", "KP0", "KPDL"},
 }
 
-//ISO holds evdev keys for an ANSI layout
+// ISO holds evdev keys for an ANSI layout
 var ISO = [][]string{
 	{"ESC", "FK01", "FK02", "FK03", "FK04", "FK05", "FK06", "FK07", "FK08", "FK09", "FK10", "FK11", "FK12", "PRSC", "SCLK", "PAUS"},
 	{"TLDE", "AE01", "AE02", "AE03", "AE04", "AE05", "AE06", "AE07", "AE08", "AE09", "AE10", "AE11", "AE12", "BKSP", "INS", "HOME", "PGUP", "NMLK", "KPDV", "KPMU", "KPSU"},
@@ -28,13 +28,14 @@ var ISO = [][]string{
 	{"LCTL", "LWIN", "LALT", "SPCE", "RALT", "RWIN", "MENU", "RCTL", "LEFT", "DOWN", "RGHT", "KP0", "KPDL"},
 }
 
-//Keyboard holds one keyboard for one modifier group
+// Keyboard holds one keyboard for one modifier group
 type Keyboard struct {
-	Name string
-	Keys [][]Key
+	Name      string
+	Modifiers []string
+	Keys      [][]Key
 }
 
-//Key holds one key. Used for rendering
+// Key holds one key. Used for rendering
 type Key struct {
 	Binding    i3parse.Binding
 	Modifier   bool
@@ -76,7 +77,7 @@ func bindingMatch(symbol string, symbolCode int, identifier string, group i3pars
 	return rKey
 }
 
-//MapKeyboard returns a Keyboard matching desired layout
+// MapKeyboard returns a Keyboard matching desired layout
 func MapKeyboard(layout string, group i3parse.ModifierGroup, modifiers map[string][]string) (Keyboard, error) {
 	var kb [][]Key
 	var kbMap [][]string
@@ -115,5 +116,5 @@ func MapKeyboard(layout string, group i3parse.ModifierGroup, modifiers map[strin
 	if name == "" {
 		name = "No modifiers"
 	}
-	return Keyboard{Name: name, Keys: kb}, nil
+	return Keyboard{Name: name, Keys: kb, Modifiers: group.Modifiers}, nil
 }

--- a/svg/output.go
+++ b/svg/output.go
@@ -56,9 +56,9 @@ func createGroup(layout string, dest string, group i3parse.ModifierGroup, modifi
 	file.Write(data)
 }
 
-//Output generates svg-files of the keyboards at the desired location
+// Output generates svg-files of the keyboards at the desired location
 func Output(wm string, layout string, dest string, filter string) {
-	modes, keys, err := i3parse.ParseFromRunning(wm)
+	modes, keys, err := i3parse.ParseFromRunning(wm, true)
 
 	if err != nil {
 		log.Fatalln(err)

--- a/text/output.go
+++ b/text/output.go
@@ -23,7 +23,7 @@ func printKeyboards(keyboards []keyboard.Keyboard, groups []i3parse.ModifierGrou
 		for _, keyRow := range kb.Keys {
 			var unused []string
 			for _, key := range keyRow {
-				if key.InUse == false {
+				if !key.InUse {
 					unused = append(unused, key.Symbol)
 				}
 			}
@@ -36,9 +36,9 @@ func printKeyboards(keyboards []keyboard.Keyboard, groups []i3parse.ModifierGrou
 	}
 }
 
-//Output prints the keyboards to os.Stdout
+// Output prints the keyboards to os.Stdout
 func Output(wm string, layout string, filter string) {
-	modes, keys, err := i3parse.ParseFromRunning(wm)
+	modes, keys, err := i3parse.ParseFromRunning(wm, true)
 
 	if err != nil {
 		log.Fatalln(err)
@@ -62,7 +62,7 @@ func Output(wm string, layout string, filter string) {
 
 	if toFilter {
 		for i, g := range groups {
-			if helpers.CompareSlices(g.Modifiers, filterMods) == false {
+			if !helpers.CompareSlices(g.Modifiers, filterMods) {
 				continue
 			}
 			printKeyboards([]keyboard.Keyboard{keyboards[i]}, []i3parse.ModifierGroup{g}, "")

--- a/web/output.go
+++ b/web/output.go
@@ -17,9 +17,9 @@ type modeKeyboards struct {
 	Keyboards []keyboard.Keyboard
 }
 
-//Output starts the server at desired port
+// Output starts the server at desired port
 func Output(wm string, port string) {
-	modes, keys, err := i3parse.ParseFromRunning(wm)
+	modes, keys, err := i3parse.ParseFromRunning(wm, true)
 
 	if err != nil {
 		log.Fatalln(err)


### PR DESCRIPTION
This adds an option to output the whole data for a layout as JSON (`i3keys json <layout>`).
I think this could be useful for further processing, for instance I'll attempt using it for an interactive tool to edit keybindings.
In practice, I simply copied and reworked the code for the `web` output, to only produce data for the requested layout, put the main keybindings under a fictitious `"(default)"` mode as the first item, and spit the JSON out.
