### PR TITLE
[wip] rounded keys (web output)

### DIFF
--- a/web/template.go
+++ b/web/template.go
@@ -127,11 +127,12 @@ var indexTmplCSS = `:root {
   
   .enterUp {
 	grid-column: auto / span 6;
+	border-radius: 5px 5px 0px 5px;
   }
   
   .enterDown {
 	border-top: none;
-	border-radius: 0px;
+	border-radius: 0px 0px 5px 5px;
 	grid-column: auto / span 5;
 	height: calc(var(--key-size) + (var(--key-size) / 4));
 	margin-top: calc(-1 * (var(--key-size) / 4) - 1px);

--- a/web/template.go
+++ b/web/template.go
@@ -66,6 +66,7 @@ var indexTmplCSS = `:root {
   
   .key {
 	border: 1px solid #000000;
+	border-radius: 5px;
 	background-color: #ffffff;
 	font-size: 0.7vw;
 	word-break: break-all;
@@ -130,6 +131,7 @@ var indexTmplCSS = `:root {
   
   .enterDown {
 	border-top: none;
+	border-radius: 0px;
 	grid-column: auto / span 5;
 	height: calc(var(--key-size) + (var(--key-size) / 4));
 	margin-top: calc(-1 * (var(--key-size) / 4) - 1px);


### PR DESCRIPTION
This one simply makes the keys slightly rounded (in the web output only).
I think it looks better overall ~but causes a small glitch where the two parts of the enter key overlap~.
edit:  the fixup commit removes the glitch.