### PR TITLE
[wip] pretty key captions (web output)

### DIFF
--- a/web/template.go
+++ b/web/template.go
@@ -217,6 +217,85 @@ iso = [
     ["modifier", "modifier", "modifier", "space", "modifier", "modifier", "modifier", "modifier", "emptySmall", "single", "single", "single", "emptySmall", "double", "single"]
 ];
 
+keyCaptions = {
+"space":        "Space",
+"exclam":       "!",
+"quotedbl":     "\"",
+"numbersign":   "#",
+"dollar":       "$",
+"percent":      "%",
+"ampersand":    "&amp;",
+"quoteright":   "'",
+"parenleft":    "(",
+"parenright":   ")",
+"asterisk":     "*",
+"plus":         "+",
+"comma":        ",",
+"minus":        "-",
+"period":       ".",
+"slash":        "/",
+"colon":        ":",
+"semicolon":    ";",
+"less":         "<",
+"equal":        "=",
+"greater":      ">",
+"question":     "?",
+"at":           "@",
+"bracketleft":  "[",
+"backslash":    "\\",
+"bracketright": "]",
+"asciicircum":  "^",
+"underscore":   "_",
+"quoteleft":    "&#96;",
+"braceleft":    "{",
+"bar":          "|",
+"braceright":   "}",
+"asciitilde":   "~",
+"agrave":       "à",
+"aacute":       "á",
+"acircumflex":  "â",
+"atilde":       "ã",
+"adiaeresis":   "ä",
+"aring":        "å",
+"ae":           "æ",
+"ccedilla":     "ç",
+"egrave":       "è",
+"eacute":       "é",
+"ecircumflex":  "ê",
+"ediaeresis":   "ë",
+"igrave":       "ì",
+"iacute":       "í",
+"icircumflex":  "î",
+"idiaeresis":   "ï",
+"eth":          "ð",
+"ntilde":       "ñ",
+"ograve":       "ò",
+"oacute":       "ó",
+"ocircumflex":  "ô",
+"otilde":       "õ",
+"odiaeresis":   "ö",
+"division":     "÷",
+"ooblique":     "ø",
+"ugrave":       "ù",
+"uacute":       "ú",
+"ucircumflex":  "û",
+"udiaeresis":   "ü",
+"yacute":       "ý",
+"thorn":        "þ",
+"ydiaeresis":   "ÿ",
+"KP_Multiply":  "KP *",
+"KP_Add":       "KP +",
+"KP_Subtract":  "KP -",
+"KP_Decimal":   "KP .",
+"KP_Divide":    "KP /",
+"KP_Equal":     "KP ="
+}
+
+function keyCaption(s) {
+  let c = keyCaptions[s];
+  return c ? c.replaceAll(" ","<br/>") : s.replaceAll("_","<br/>");
+}
+
 let keyboardHolder = document.querySelector('#keyboard-holder');
 
 function liLink(name, id) {
@@ -338,7 +417,7 @@ function generateKeyboardGroup(kbLayout, generated, headingID) {
                     enterHit = gHit
                 }
 
-                keyEl.innerHTML = '<span class="txt">' + generated.Keys[i][k].Symbol + '</span>';
+                keyEl.innerHTML = '<span class="txt">' + keyCaption(generated.Keys[i][k].Symbol) + '</span>';
 
                 k++;
             }


### PR DESCRIPTION
This one maps the keysym to a shorter, more readable caption (for instance, `parenleft` -> `(`, `KP_Divide` -> `KP /`).
Unknown symbols are unchanged, besides breaking on underscores (makes those long identifiers wrap nicely).
I think it looks better, and allows to increase the relative font size a little.

Issues:
- the change hides the real keysym (it could be shown on hover, like the command)
- the mapping only includes a few of the most common ones (shouldn't be a problem in practice, at least for Latin scripts)
- uses hardcoded characters, for most of them HTML entities would be safer
- it's done in the javascript, but for the svg output would have to be done again in go (trivial but I hate duplication)

If you have suggestions, I have some time (for now)
