### PR TITLE
Support the case-insensitive symbol names.

### DIFF
--- a/keyboard/layouts.go
+++ b/keyboard/layouts.go
@@ -98,7 +98,7 @@ func bindingMatch(symbol string, symbolCode int, identifier string, group i3pars
 	}
 
 	for _, key := range group.Bindings {
-		if symbol == key.Key {
+		if strings.ToLower(symbol) == strings.ToLower(key.Key) {
 			rKey.InUse = true
 			rKey.Binding = key
 			return rKey


### PR DESCRIPTION
This PR fixes #39. I tested it on my local. @elder-n00b, thank you for your help!

---

This commit is to support that the symbol names that are case-insensitive from the `/usr/include/X11/keysymdef.h` - `XK_something` are shown as occupied (red color) on the page by the `i3keys web`. Because sway supports the symbol names.

The symbol names are such as `Semicolon` for the `XK_semicolon` in the `keysymdef.h`.

